### PR TITLE
vulkan-headers: Update to version 1.3.277

### DIFF
--- a/rpm/vulkan-headers.spec
+++ b/rpm/vulkan-headers.spec
@@ -1,7 +1,7 @@
 # Based on Fedora packaging
 
 Name:           vulkan-headers
-Version:        1.3.259
+Version:        1.3.277
 Release:        1
 Summary:        Vulkan Header files and API registry
 License:        ASL 2.0 or MIT
@@ -18,11 +18,11 @@ Vulkan Header files and API registry
 %autosetup -n %{name}-%{version}/%{name}
 
 %build
-%cmake .
-%make_build
+%cmake
+%cmake_build
 
 %install
-%make_install
+%cmake_install
 
 %files
 %license LICENSE.md LICENSES/Apache-2.0.txt LICENSES/MIT.txt


### PR DESCRIPTION
Use new cmake macros.

[vulkan-headers] Update to version 1.3.277. JB#60999